### PR TITLE
oClv4bKl: Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "loop54-js-connector",
   "version": "1.3.5454545454-build-number",
   "description": "JS Wrapper for Loop54 JSON API",
+  "license": "BSD-3-Clause",
   "main": "lib/loop54-js-connector-client.js",
   "scripts": {
     "clean": "rm -rf ./lib",


### PR DESCRIPTION
This is a meaningful change, but its primary purpose is to test the build server integration now that we've migrated code review to GitHub.