### PR TITLE
Default cookie path to / when input value is not set

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -25,7 +25,7 @@ let cookies = {
                 break;
             }
         }
-        document.cookie = encodeURIComponent(sKey) + "=" + encodeURIComponent(sValue) + sExpires + (sDomain ? "; domain=" + sDomain : "") + (sPath ? "; path=" + sPath : "") + (bSecure ? "; secure" : "");
+        document.cookie = encodeURIComponent(sKey) + "=" + encodeURIComponent(sValue) + sExpires + (sDomain ? "; domain=" + sDomain : "") + "; path=" + (sPath ? sPath : "/") + (bSecure ? "; secure" : "");
         return true;
     },
     
@@ -33,7 +33,7 @@ let cookies = {
         if (!this.hasItem(sKey)) {
             return false;
         }
-        document.cookie = encodeURIComponent(sKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT" + (sDomain ? "; domain=" + sDomain : "") + (sPath ? "; path=" + sPath : "");
+        document.cookie = encodeURIComponent(sKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT" + (sDomain ? "; domain=" + sDomain : "") + "; path=" + (sPath ? sPath : "/");
         return true;
     },
     


### PR DESCRIPTION
Since setItem is never called with the sPath property set we ended up setting cookies without path.
If no path is present during creation it will default to the current URL path, that in turn would generate many different userId cookies for one site.

Another solution is to always pass "/" to setItem when setting the user cookie. Not sure which approach is best.