### PR TITLE
Pass "/" as path when setting user id cookie

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -14,7 +14,7 @@ let core = {
         for (var i = 0; i < 10; i++) {
             text += possible.charAt(Math.floor(Math.random() * possible.length));
         }
-        cookies.setItem("Loop54User", text, 365 * 24 * 60 * 60); //365 days
+        cookies.setItem("Loop54User", text, 365 * 24 * 60 * 60, "/"); //365 days
         return text;
     },
 


### PR DESCRIPTION
Since setItem is never called with the sPath property set we ended up setting cookies without path.
If no path is present during creation it will default to the current URL path, that in turn would generate many different userId cookies for one site.

Now we make sure to pass / as path when setting the user id cookie