### PR TITLE
Fix bug with how error is returned from the main call function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loop54-js-connector",
-  "version": "1.6.5454545454-build-number",
+  "version": "1.7.5454545454-build-number",
   "description": "JS Wrapper for Loop54 JSON API",
   "license": "BSD-3-Clause",
   "main": "lib/loop54-js-connector-client.js",

--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,7 @@ import cookies from "./cookies.js";
 let core = {
 
     versions: {
-        libVersion: "1.5.5454545454-build-number", //"5454545454-build-number" will be replaced by teamcity. also in package.json
+        libVersion: "1.7.5454545454-build-number", //"5454545454-build-number" will be replaced by teamcity. also in package.json
         apiVersion: "V3"
     },
 


### PR DESCRIPTION
Problem is that the catch returns an error object which does not contain the data property directly on it. This bug caused the catch to always return a generic generic error message.

By changing so that we look at `error.reponse.data` we now return the error from the server to the client.

(https://axios-http.com/docs/handling_errors)