### PR TITLE
XfodDvJh: Unify version definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ A Linux or MacOS environment is required. Windows is not supported and the npm c
 3. run `npm run dev` to start the webserver, open up
    http://localhost:3001/#search and try out the basic features
 
+### Pull requests
+
+Before creating a pull request:
+- commit your changes
+- update the package's version number in `package.json`
+- run `npm run sync-version`
+  - This synchronises the versions in `package.json`, `package-lock.json` and `core.js`.
+- commit the version related changes with the new version number as the commit message, e.g. `1.14`.
+- push to remote and open pull request
+
+Committing version related changes separately from implementation makes it easier to cherry-pick specific changes.
+Also, spotting version increments in the git history is much quicker.
+
 ### Build
 
 run `npm run bundle` to build the source code into /lib folder

--- a/bundle.js
+++ b/bundle.js
@@ -3,16 +3,16 @@ const runAll = require("npm-run-all");
 const runopts = {
     parallel : true,
     stdout   : process.stdout,
+    stderr   : process.stderr,
 };
 
 console.log("Running clean");
 runAll(["clean"], runopts)
     .then(() => {
         console.log("Running build");
-        runAll(["build-*"], runopts)
-            .then(() => {
-                console.log("Running uglify");
-                runAll(["uglify"], runopts)
-            })
+        return runAll(["build-*"], runopts);
     })
-    .catch(console.error);
+    .then(() => {
+        console.log("Running uglify");
+        return runAll(["uglify"], runopts)
+    });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loop54-js-connector",
-  "version": "1.13.5454545454-build-number",
+  "version": "1.14.5454545454-build-number",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "loop54-js-connector",
-      "version": "1.13.5454545454-build-number",
+      "version": "1.14.5454545454-build-number",
       "license": "BSD-3-Clause",
       "dependencies": {
         "axios": "^1"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,14 @@
     "dev": "node launch-dev.js",
     "watch": "watchify src/loop54.js -o lib/loop54-js-connector.js -t [ babelify ]",
     "server": "node server.js",
-    "build-connector": "browserify src/loop54.js -o lib/loop54-js-connector.js -t [ babelify --global --only [ src node_modules\/axios ] ]",
+    "build-connector": "browserify src/loop54.js -o lib/loop54-js-connector.js -t [ babelify --global --only [ src node_modules/axios ] ]",
     "build-client": "rollup src/client.js -e axios -o lib/loop54-js-connector-client.js -f cjs",
     "uglify": "uglifyjs lib/loop54-js-connector.js -o lib/loop54-js-connector.min.js",
-    "bundle": "node bundle.js",
+    "sync-version": "node versioning.js --sync && npm i",
+    "bundle": "node versioning.js --verify && node bundle.js",
+    "ci-verify": "node versioning.js --verify",
+    "ci-set-build-number": "node versioning.js --set-build-number",
+    "ci-bundle": "node bundle.js",
     "test": "mocha --require @babel/register ./test/lib-test.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loop54-js-connector",
-  "version": "1.13.5454545454-build-number",
+  "version": "1.14.5454545454-build-number",
   "description": "JS Wrapper for Loop54 JSON API",
   "license": "BSD-3-Clause",
   "main": "lib/loop54-js-connector-client.js",

--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,9 @@ import cookies from "./cookies.js";
 let core = {
 
     versions: {
-        libVersion: "1.12.5454545454-build-number", //"5454545454-build-number" will be replaced by teamcity. also in package.json
+        // Do not change `libVersion` manually. See README.
+        // The "5454545454-build-number" part will be replaced automatically during the build process.
+        libVersion: "1.12.5454545454-build-number",
         apiVersion: "V3"
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -6,7 +6,7 @@ let core = {
     versions: {
         // Do not change `libVersion` manually. See README.
         // The "5454545454-build-number" part will be replaced automatically during the build process.
-        libVersion: "1.12.5454545454-build-number",
+        libVersion: "1.14.5454545454-build-number",
         apiVersion: "V3"
     },
 

--- a/versioning.js
+++ b/versioning.js
@@ -1,0 +1,69 @@
+const packageFile = `./package.json`;
+const coreFile = `./src/core.js`;
+
+
+const fs = require(`fs`);
+const { version } = require(packageFile);
+
+const argSetBuildNumber = process.argv[2] === `--set-build-number`;
+const argSyncVersions = process.argv[2] === `--sync`;
+const argVerifyVersions = process.argv[2] === `--verify`;
+
+
+// The build number is to be set by the TC build pipeline through string replacement.
+const buildNumber = `TC-BUILD-NUMBER`;
+
+// This regex is required to keep all occurrences of the library's version number in sync.
+const placeholderRegex = /(\d+\.\d+\.)5454545454-build-number\b/;
+
+
+
+const coreText = fs.readFileSync(coreFile, `utf8`);
+
+const coreMatch = coreText.match(placeholderRegex);
+
+if (!coreMatch) {
+    throw Error(`Could not find version in ${coreFile}. Was looking for ${placeholderRegex.toString()}`);
+}
+
+const versionToVerify = coreMatch[0];
+
+console.log(`Matched version:`, versionToVerify);
+
+
+
+if (argSetBuildNumber) {
+    const packageText = fs.readFileSync(packageFile, `utf8`);
+
+    const replacedPackage = packageText.replace(placeholderRegex, `$1${buildNumber}`);
+    const replacedCore = coreText.replace(placeholderRegex, `$1${buildNumber}`);
+
+    fs.writeFileSync(packageFile, replacedPackage);
+    fs.writeFileSync(coreFile, replacedCore);
+
+    console.log(`Injected build number:`, buildNumber);
+    return;
+}
+
+if (argSyncVersions) {
+    const replacedCore = coreText.replace(placeholderRegex, version);
+
+    fs.writeFileSync(coreFile, replacedCore);
+
+    console.log(`Versions synced to:`, version);
+    return;
+}
+
+if (argVerifyVersions) {
+    if (version !== versionToVerify) {
+        throw Error(`Versions are out of sync. See README about version syncing.\n${packageFile}: ${version}\n${coreFile}: ${versionToVerify}`);
+    }
+
+    console.log(`Version successfully verified.`);
+    return;
+}
+
+
+console.log();
+console.log(`WARNING: No parameter specified. Script did nothing. Check source for available parameters.`);
+console.log();


### PR DESCRIPTION
Introduce build step at Node-level that copies the version from `package.json` into the JS output.
This reduces the number of locations where the version is defined from two to one.